### PR TITLE
build(spark): update Dockerfile and scripts to support Python 3.12

### DIFF
--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -2,17 +2,24 @@ FROM bitnami/spark:3.4.1
 
 USER root
 RUN apt-get update && \
-    apt-get install -y wget gcc python3-dev build-essential software-properties-common && \
+    apt-get install -y wget gcc python3-dev build-essential software-properties-common libffi-dev \
+    libssl-dev openssl && \
     wget https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz && \
     tar -xf Python-3.12.3.tgz && \
     cd Python-3.12.3 && \
-    ./configure --enable-optimizations && \
+    ./configure --enable-optimizations --enable-loadable-sqlite-extensions --with-system-ffi --with-ssl && \
     make -j $(nproc) && \
-    make altinstall && \
+    make install && \
     cd .. && rm -rf Python-3.12.3* && \
-    ln -sf /usr/local/bin/python3.12 /usr/bin/python3 && \
-    ln -sf /usr/local/bin/pip3.12 /usr/bin/pip3 && \
-    wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz && \
+    rm -f /opt/bitnami/python/bin/python3 && \
+    rm -f /opt/bitnami/python/bin/pip3 && \
+    ln -sf /usr/local/bin/python3.12 /opt/bitnami/python/bin/python3 && \
+    ln -sf /usr/local/bin/pip3.12 /opt/bitnami/python/bin/pip3 && \
+    python3 -m ensurepip && \
+    pip3 install --upgrade pip
+
+# Install Java 11
+RUN wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz && \
     tar -xvzf openjdk-11+28_linux-x64_bin.tar.gz && \
     mv jdk-11 /opt/ && \
     rm openjdk-11+28_linux-x64_bin.tar.gz && \
@@ -24,15 +31,14 @@ RUN mkdir -p /opt/bitnami/spark/conf && \
     touch /opt/bitnami/spark/conf/spark-env.sh && \
     echo 'export JAVA_HOME=/opt/jdk-11' >> /opt/bitnami/spark/conf/spark-env.sh && \
     echo 'export PATH=$JAVA_HOME/bin:$PATH' >> /opt/bitnami/spark/conf/spark-env.sh && \
-    echo 'export PYSPARK_PYTHON=/usr/bin/python3' >> /opt/bitnami/spark/conf/spark-env.sh && \
-    echo 'export PYSPARK_DRIVER_PYTHON=/usr/bin/python3' >> /opt/bitnami/spark/conf/spark-env.sh && \
-    chown -R 1001:root /opt/bitnami && \
-    chmod -R g+rwX /opt/bitnami
+    echo 'export PYSPARK_PYTHON=/opt/bitnami/python/bin/python3' >> /opt/bitnami/spark/conf/spark-env.sh && \
+    echo 'export PYSPARK_DRIVER_PYTHON=/opt/bitnami/python/bin/python3' >> /opt/bitnami/spark/conf/spark-env.sh
 
+# Set up Python environment and install requirements
 COPY requirements-spark.txt /opt/bitnami/spark/requirements.txt
-RUN chown -R 1001:root /opt/bitnami/spark && \
-    chmod -R 755 /opt/bitnami/spark && \
-    pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir -r /opt/bitnami/spark/requirements.txt
+RUN mkdir -p /opt/bitnami/python && \
+    chown -R 1001:root /opt/bitnami && \
+    chmod -R 755 /opt/bitnami && \
+    /opt/bitnami/python/bin/pip3 install --no-cache-dir -r /opt/bitnami/spark/requirements.txt
 
 USER 1001

--- a/Spark/tests/Bashcomands.sh
+++ b/Spark/tests/Bashcomands.sh
@@ -1,1 +1,3 @@
-docker exec spark-master spark-submit --master spark://spark-master:7077 /opt/bitnami/spark/scripts/rdd.py
+docker exec spark-master spark-submit --master spark://spark-master:7077 /opt/spark/scripts/RDD.py
+
+

--- a/Spark/tests/fix_python_path.bat
+++ b/Spark/tests/fix_python_path.bat
@@ -1,0 +1,19 @@
+@echo off
+echo Fixing Python paths in spark-master...
+
+REM Remove all Python symlinks
+docker exec -u root spark-master bash -c "rm -f /usr/bin/python* /usr/bin/pip* /usr/local/bin/python* /usr/local/bin/pip*"
+
+REM Create new symlinks to Python 3.12
+docker exec -u root spark-master bash -c "ln -sf /usr/local/bin/python3.12 /usr/bin/python3 && ln -sf /usr/local/bin/python3.12 /usr/bin/python && ln -sf /usr/local/bin/pip3.12 /usr/bin/pip3 && ln -sf /usr/local/bin/pip3.12 /usr/bin/pip"
+
+REM Update Spark environment configuration
+docker exec -u root spark-master bash -c "echo 'export PYSPARK_PYTHON=/usr/bin/python3' > /opt/bitnami/spark/conf/spark-env.sh && echo 'export PYSPARK_DRIVER_PYTHON=/usr/bin/python3' >> /opt/bitnami/spark/conf/spark-env.sh"
+
+REM Verify Python version
+echo Verifying Python configuration...
+docker exec spark-master python3 --version
+docker exec spark-master pip3 --version
+
+echo Done.
+pause

--- a/Spark/tests/install_python.bat
+++ b/Spark/tests/install_python.bat
@@ -1,0 +1,21 @@
+@echo off
+echo Installing Python 3.12.3 and dependencies...
+
+docker exec -it -u root spark-master bash -c "apt-get update && apt-get install -y wget gcc python3-dev build-essential software-properties-common libffi-dev && wget https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz && tar -xf Python-3.12.3.tgz && cd Python-3.12.3 && ./configure --enable-optimizations --enable-loadable-sqlite-extensions --with-system-ffi && make -j $(nproc) && make install && cd .. && rm -rf Python-3.12.3* && rm -f /opt/bitnami/python/bin/python3 && rm -f /opt/bitnami/python/bin/pip3 && ln -sf /usr/local/bin/python3.12 /opt/bitnami/python/bin/python3 && ln -sf /usr/local/bin/pip3.12 /opt/bitnami/python/bin/pip3 && python3 -m ensurepip && pip3 install --upgrade pip"
+
+echo.
+echo Verifying Python installation...
+docker exec -it spark-master /opt/bitnami/python/bin/python3 --version
+docker exec -it spark-master python3 --version
+
+echo.
+echo Verifying pip installation...
+docker exec -it spark-master /opt/bitnami/python/bin/pip3 --version
+
+echo.
+echo Testing Python ctypes...
+docker exec -it spark-master /opt/bitnami/python/bin/python3 -c "import ctypes; print('ctypes available')"
+
+echo.
+echo Installation and verification complete.
+pause

--- a/docs/bash_commands.md
+++ b/docs/bash_commands.md
@@ -59,5 +59,5 @@ docker exec airflow-webserver java -version
 # Test DAG execution - Runs a specific DAG for testing purposes
 docker exec -it airflow-webserver bash -c "airflow dags test spark_user_etl 2025-04-01"
 
-docker exec -it airflow-webserver bash -c "airflow dags test spark_rdd_job 2025-04-03"
+docker exec -it airflow-webserver bash -c "airflow dags test spark_rdd_job 2025-04-04"
 

--- a/install_spark_dependencies.bat
+++ b/install_spark_dependencies.bat
@@ -9,6 +9,10 @@ echo Checking Python version in spark-worker...
 docker exec spark-worker python3 --version
 docker exec spark-worker pip3 --version
 
+echo Installing Python dependencies...
+docker cp requirements-spark.txt spark-master:/opt/bitnami/spark/requirements.txt
+docker exec -u root spark-master pip3 install -r /opt/bitnami/spark/requirements.txt
+
 echo Setting PYSPARK_PYTHON and PYSPARK_DRIVER_PYTHON in containers...
 docker exec -u root spark-master bash -c "echo 'export PYSPARK_PYTHON=/usr/bin/python3' >> /opt/bitnami/spark/conf/spark-env.sh"
 docker exec -u root spark-master bash -c "echo 'export PYSPARK_DRIVER_PYTHON=/usr/bin/python3' >> /opt/bitnami/spark/conf/spark-env.sh"
@@ -18,6 +22,9 @@ docker exec -u root spark-worker bash -c "echo 'export PYSPARK_DRIVER_PYTHON=/us
 echo Verifying PySpark configuration...
 docker exec spark-master bash -c "source /opt/bitnami/spark/conf/spark-env.sh && echo PYSPARK_PYTHON=$PYSPARK_PYTHON"
 docker exec spark-master bash -c "source /opt/bitnami/spark/conf/spark-env.sh && echo PYSPARK_DRIVER_PYTHON=$PYSPARK_DRIVER_PYTHON"
+
+echo Verifying Python packages...
+docker exec spark-master pip3 list | findstr requests
 
 echo Installation completed successfully.
 pause


### PR DESCRIPTION
Update Dockerfile.spark to install Python 3.12 with additional configurations like SSL and SQLite support. Modify test scripts and installation scripts to handle Python dependencies and environment setup correctly. This ensures compatibility with the latest Python version and improves the Spark environment configuration.